### PR TITLE
Fix multiple ENV in Dockerfile

### DIFF
--- a/buildfiles/Dockerfile
+++ b/buildfiles/Dockerfile
@@ -1,11 +1,10 @@
 FROM python:3.10-slim as python-base
 
-ENV POETRY_VERSION=1.2.0
-ENV POETRY_HOME=/opt/poetry
-ENV POETRY_VENV=/opt/poetry-venv
-
-ENV POETRY_CACHE_DIR=/opt/.cache
-
+ENV POETRY_VERSION=1.2.0 \
+    POETRY_HOME=/opt/poetry \
+    POETRY_VENV=/opt/poetry-venv \
+    POETRY_CACHE_DIR=/opt/.cache
+    
 FROM python-base as poetry-base
 
 RUN python3 -m venv $POETRY_VENV \
@@ -20,8 +19,8 @@ ENV PATH="${PATH}:${POETRY_VENV}/bin"
 WORKDIR /app
 COPY ../poetry.lock pyproject.toml ./
 
-RUN poetry check
-RUN poetry install --no-interaction --no-cache --no-root
+RUN poetry check && \
+    poetry install --no-interaction --no-cache --no-root
 
 COPY .. .
 CMD ["poetry", "run", "python", "-m", "src.bot"]


### PR DESCRIPTION
Multiple declaration ENV for couple of variables is common-wide mistake, because of Docker behaviour, which makes new layer for every declaration of ENV statement.